### PR TITLE
Update .NET version to 8.0 and Huddly SDK to version 2.22.4

### DIFF
--- a/CameraInfo/CameraInfo.csproj
+++ b/CameraInfo/CameraInfo.csproj
@@ -2,16 +2,16 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Huddly.Sdk" Version="2.5.0" />
-		<PackageReference Include="Huddly.Sdk.Extensions" Version="2.5.0" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+		<PackageReference Include="Huddly.Sdk" Version="2.22.4" />
+		<PackageReference Include="Huddly.Sdk.Extensions" Version="2.22.4" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.1" />
 	</ItemGroup>
 
 </Project>

--- a/Crew/Crew.csproj
+++ b/Crew/Crew.csproj
@@ -1,17 +1,17 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Huddly.Sdk" Version="2.5.0" />
-    <PackageReference Include="Huddly.Sdk.Extensions" Version="2.5.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+    <PackageReference Include="Huddly.Sdk" Version="2.22.4" />
+    <PackageReference Include="Huddly.Sdk.Extensions" Version="2.22.4" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.1" />
   </ItemGroup>
 
 </Project>

--- a/Detections/Detections.csproj
+++ b/Detections/Detections.csproj
@@ -2,16 +2,16 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Huddly.Sdk" Version="2.5.0" />
-    <PackageReference Include="Huddly.Sdk.Extensions" Version="2.5.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+    <PackageReference Include="Huddly.Sdk" Version="2.22.4" />
+    <PackageReference Include="Huddly.Sdk.Extensions" Version="2.22.4" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.1" />
   </ItemGroup>
 
 </Project>

--- a/DeviceLogs/DeviceLogs.csproj
+++ b/DeviceLogs/DeviceLogs.csproj
@@ -2,16 +2,16 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Huddly.Sdk" Version="2.5.0" />
-    <PackageReference Include="Huddly.Sdk.Extensions" Version="2.5.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+    <PackageReference Include="Huddly.Sdk" Version="2.22.4" />
+    <PackageReference Include="Huddly.Sdk.Extensions" Version="2.22.4" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.1" />
   </ItemGroup>
 
 </Project>

--- a/FramingModes/FramingModes.csproj
+++ b/FramingModes/FramingModes.csproj
@@ -2,16 +2,16 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Huddly.Sdk" Version="2.5.0" />
-		<PackageReference Include="Huddly.Sdk.Extensions" Version="2.5.0" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+		<PackageReference Include="Huddly.Sdk" Version="2.22.4" />
+		<PackageReference Include="Huddly.Sdk.Extensions" Version="2.22.4" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.1" />
 	</ItemGroup>
 
 </Project>

--- a/FramingModes/Program.cs
+++ b/FramingModes/Program.cs
@@ -39,7 +39,7 @@ internal class Program
             var supportedFeatures = await lastDevice.GetSupportedFeatures();
 
             Console.WriteLine($"Supported framing modes:");
-            foreach (FramingMode supportedFraming in supportedFeatures.Framing ?? Enumerable.Empty<FramingMode>())
+            foreach (FramingMode supportedFraming in supportedFeatures.Value?.Framing ?? Enumerable.Empty<FramingMode>())
             {
                 Console.WriteLine($"==== {supportedFraming}");
             }

--- a/Upgrade/Upgrade.csproj
+++ b/Upgrade/Upgrade.csproj
@@ -2,16 +2,16 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Huddly.Sdk" Version="2.5.0" />
-    <PackageReference Include="Huddly.Sdk.Extensions" Version="2.5.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+    <PackageReference Include="Huddly.Sdk" Version="2.22.4" />
+    <PackageReference Include="Huddly.Sdk.Extensions" Version="2.22.4" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The samples can still be built with .NET6 by changing TargetFramework back to `net6.0` and reverting Microsoft.Extensions dependencies to v8.0.1