### PR TITLE
Code clean-up

### DIFF
--- a/CameraInfo/CameraInfo.csproj
+++ b/CameraInfo/CameraInfo.csproj
@@ -5,6 +5,8 @@
 		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
+		<EnableNETAnalyzers>true</EnableNETAnalyzers>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/CameraInfo/Program.cs
+++ b/CameraInfo/Program.cs
@@ -6,7 +6,7 @@ namespace CameraInfo;
 
 internal class Program
 {
-    static void Main(string[] _)
+    static async Task Main(string[] _)
     {
         var services = new ServiceCollection();
         services.AddLogging(configure => configure.AddConsole().SetMinimumLevel(LogLevel.Debug));
@@ -43,8 +43,6 @@ internal class Program
             // Device firmware version
             var fwVersion = (await lastDevice.GetFirmwareVersion()).GetValueOrThrow();
             Console.WriteLine($"Device firmware version: {fwVersion?.ToString() ?? "unknown"}");
-
-            Console.WriteLine("Press any key to quit...");
         };
         huddlySdk.DeviceDisconnected += (o, e) =>
         {
@@ -52,7 +50,16 @@ internal class Program
             lastDevice = null;
         };
 
-        huddlySdk.StartMonitoring();
-        Console.ReadKey();
+        var cts = new CancellationTokenSource();
+
+        Console.WriteLine("\n\nPress Control+C to quit the sample.\n\n");
+        Console.CancelKeyPress += (sender, eventArgs) =>
+        {
+            Console.WriteLine("Cancellation requested; will exit.");
+            eventArgs.Cancel = true;
+            cts.Cancel();
+        };
+
+        await huddlySdk.StartMonitoring(ct: cts.Token);
     }
 }

--- a/CameraInfo/Program.cs
+++ b/CameraInfo/Program.cs
@@ -21,6 +21,7 @@ internal class Program
 
         // Should always be disposed after use
         using var huddlySdk = sp.GetRequiredService<ISdk>();
+        var cts = new CancellationTokenSource();
 
         IDevice? lastDevice = null;
         huddlySdk.DeviceConnected += async (o, e) =>
@@ -41,7 +42,7 @@ internal class Program
             );
 
             // Device firmware version
-            var fwVersion = (await lastDevice.GetFirmwareVersion()).GetValueOrThrow();
+            var fwVersion = (await lastDevice.GetFirmwareVersion(cts.Token)).GetValueOrThrow();
             Console.WriteLine($"Device firmware version: {fwVersion?.ToString() ?? "unknown"}");
         };
         huddlySdk.DeviceDisconnected += (o, e) =>
@@ -49,8 +50,6 @@ internal class Program
             Console.WriteLine($"Device {e.Device.Id} disconnected");
             lastDevice = null;
         };
-
-        var cts = new CancellationTokenSource();
 
         Console.WriteLine("\n\nPress Control+C to quit the sample.\n\n");
         Console.CancelKeyPress += (sender, eventArgs) =>

--- a/CameraInfo/Program.cs
+++ b/CameraInfo/Program.cs
@@ -28,13 +28,13 @@ internal class Program
             lastDevice = e.Device;
 
             // Properties containing camera info
-            string serialNumber = lastDevice.Serial;
+            var serialNumber = lastDevice.Serial;
             var manufacturer = lastDevice.Manufacturer;
             var deviceModel = lastDevice.Model;
 
             // Model name as a string
-            var deviceNameResult = await lastDevice.GetName();
-            string deviceName = deviceNameResult.IsSuccess ? deviceNameResult.Value : "Unknown";
+            var deviceNameResult = await lastDevice.GetName(cts.Token);
+            var deviceName = deviceNameResult.IsSuccess ? deviceNameResult.Value : "Unknown";
 
             Console.WriteLine(
                 $"Device type {deviceModel} with serial number {serialNumber} and name {deviceName} is manufactured by {manufacturer}."

--- a/CameraInfo/Program.cs
+++ b/CameraInfo/Program.cs
@@ -1,6 +1,4 @@
-﻿using Huddly.Device.Model;
-using Huddly.Sdk;
-using Huddly.Sdk.Models;
+﻿using Huddly.Sdk;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -32,11 +30,11 @@ internal class Program
 
             // Properties containing camera info
             string serialNumber = lastDevice.Serial;
-            Manufacturer manufacturer = lastDevice.Manufacturer;
-            DeviceModel deviceModel = lastDevice.Model;
+            var manufacturer = lastDevice.Manufacturer;
+            var deviceModel = lastDevice.Model;
 
             // Model name as a string
-            Result<string> deviceNameResult = await lastDevice.GetName();
+            var deviceNameResult = await lastDevice.GetName();
             string deviceName = deviceNameResult.IsSuccess ? deviceNameResult.Value : "Unknown";
 
             Console.WriteLine(
@@ -44,7 +42,7 @@ internal class Program
             );
 
             // Device firmware version
-            FirmwareVersion fwVersion = (await lastDevice.GetFirmwareVersion()).GetValueOrThrow();
+            var fwVersion = (await lastDevice.GetFirmwareVersion()).GetValueOrThrow();
             Console.WriteLine($"Device firmware version: {fwVersion?.ToString() ?? "unknown"}");
 
             Console.WriteLine("Press any key to quit...");

--- a/CameraInfo/Program.cs
+++ b/CameraInfo/Program.cs
@@ -8,7 +8,6 @@ internal class Program
 {
     static void Main(string[] _)
     {
-        var cts = new CancellationTokenSource();
         var services = new ServiceCollection();
         services.AddLogging(configure => configure.AddConsole().SetMinimumLevel(LogLevel.Debug));
 

--- a/Crew/Crew.csproj
+++ b/Crew/Crew.csproj
@@ -5,6 +5,8 @@
 		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
+		<EnableNETAnalyzers>true</EnableNETAnalyzers>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Crew/Crew.csproj
+++ b/Crew/Crew.csproj
@@ -1,17 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Huddly.Sdk" Version="2.22.4" />
-    <PackageReference Include="Huddly.Sdk.Extensions" Version="2.22.4" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.1" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Huddly.Sdk" Version="2.22.4" />
+		<PackageReference Include="Huddly.Sdk.Extensions" Version="2.22.4" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.1" />
+	</ItemGroup>
 
 </Project>

--- a/Crew/Program.cs
+++ b/Crew/Program.cs
@@ -4,66 +4,69 @@ using Huddly.Sdk.Models;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
-namespace Crew
+namespace Crew;
+
+internal class Program
 {
-    internal class Program
+    static void Main(string[] _)
     {
-        static void Main(string[] _)
+        var cts = new CancellationTokenSource();
+        var services = new ServiceCollection();
+        services.AddLogging(configure => configure.AddConsole().SetMinimumLevel(LogLevel.Debug));
+
+        services.AddHuddlySdk(configure =>
         {
-            var cts = new CancellationTokenSource();
-            var services = new ServiceCollection();
-            services.AddLogging(configure => configure.AddConsole().SetMinimumLevel(LogLevel.Debug));
+            configure.UseUsbDeviceMonitor();
+            configure.UseIpDeviceMonitor();
+        });
 
-            services.AddHuddlySdk(configure =>
+        var sp = services.BuildServiceProvider();
+
+        // Should always be disposed after use
+        using var huddlySdk = sp.GetRequiredService<ISdk>();
+
+        IDevice? lastDevice = null;
+        huddlySdk.DeviceConnected += async (o, e) =>
+        {
+            if (!(e.Device is { Model: DeviceModel.Crew } and IMultiCameraDevice))
             {
-                configure.UseUsbDeviceMonitor();
-                configure.UseIpDeviceMonitor();
-            });
+                Console.WriteLine($"Device {e.Device.Model} is not a Crew-device");
+                return;
+            }
 
-            var sp = services.BuildServiceProvider();
+            // Crew devices support most normal IDevice methods as seen in the other samples.
+            // In addition, it has an API that is unique for only multicamera devices, which is demonstrated here
 
-            // Should always be disposed after use
-            using var huddlySdk = sp.GetRequiredService<ISdk>();
+            lastDevice = e.Device;
 
-            IDevice? lastDevice = null;
-            huddlySdk.DeviceConnected += async (o, e) =>
+            var crewDevice = (IMultiCameraDevice)e.Device;
+            var connectedCamerasResult = await crewDevice.GetConnectedCameras();
+            if (!connectedCamerasResult.IsSuccess)
             {
-                if (!(e.Device is { Model: DeviceModel.Crew } and IMultiCameraDevice))
-                {
-                    Console.WriteLine($"Device {e.Device.Model} is not a Crew-device");
-                    return;
-                }
-
-                // Crew devices support most normal IDevice methods as seen in the other samples.
-                // In addition, it has an API that is unique for only multicamera devices, which is demonstrated here
-
-                lastDevice = e.Device;
-
-                var crewDevice = (IMultiCameraDevice)e.Device;
-                var connectedCamerasResult = await crewDevice.GetConnectedCameras();
-                if (!connectedCamerasResult.IsSuccess)
-                {
-                    Console.WriteLine($"Failed getting connected cameras: {connectedCamerasResult.Message}");
-                    return;
-                }
-                var crewCameraStatuses = connectedCamerasResult.Value;
-                Console.WriteLine($"Crew system with the following cameras connected:");
-                foreach (CameraStatus cameraStatus in crewCameraStatuses)
-                {
-                    Console.WriteLine($"\tSerial: {cameraStatus.Serial}, Type: {cameraStatus.Type}, Availability: {cameraStatus.Availability}");
-                }
-            };
-            huddlySdk.DeviceDisconnected += (o, e) =>
+                Console.WriteLine(
+                    $"Failed getting connected cameras: {connectedCamerasResult.Message}"
+                );
+                return;
+            }
+            var crewCameraStatuses = connectedCamerasResult.Value;
+            Console.WriteLine($"Crew system with the following cameras connected:");
+            foreach (CameraStatus cameraStatus in crewCameraStatuses)
             {
-                Console.WriteLine($"Device {e.Device.Id} disconnected");
-                if (e.Device.Id == lastDevice?.Id)
-                {
-                    lastDevice = null;
-                }
-            };
+                Console.WriteLine(
+                    $"\tSerial: {cameraStatus.Serial}, Type: {cameraStatus.Type}, Availability: {cameraStatus.Availability}"
+                );
+            }
+        };
+        huddlySdk.DeviceDisconnected += (o, e) =>
+        {
+            Console.WriteLine($"Device {e.Device.Id} disconnected");
+            if (e.Device.Id == lastDevice?.Id)
+            {
+                lastDevice = null;
+            }
+        };
 
-            huddlySdk.StartMonitoring();
-            Console.ReadKey();
-        }
+        huddlySdk.StartMonitoring();
+        Console.ReadKey();
     }
 }

--- a/Crew/Program.cs
+++ b/Crew/Program.cs
@@ -39,14 +39,14 @@ namespace Crew
 
                 lastDevice = e.Device;
 
-                IMultiCameraDevice crewDevice = (IMultiCameraDevice)e.Device;
-                Result<IList<CameraStatus>> connectedCamerasResult = await crewDevice.GetConnectedCameras();
+                var crewDevice = (IMultiCameraDevice)e.Device;
+                var connectedCamerasResult = await crewDevice.GetConnectedCameras();
                 if (!connectedCamerasResult.IsSuccess)
                 {
                     Console.WriteLine($"Failed getting connected cameras: {connectedCamerasResult.Message}");
                     return;
                 }
-                IList<CameraStatus> crewCameraStatuses = connectedCamerasResult.Value;
+                var crewCameraStatuses = connectedCamerasResult.Value;
                 Console.WriteLine($"Crew system with the following cameras connected:");
                 foreach (CameraStatus cameraStatus in crewCameraStatuses)
                 {

--- a/Crew/Program.cs
+++ b/Crew/Program.cs
@@ -22,6 +22,7 @@ internal class Program
 
         // Should always be disposed after use
         using var huddlySdk = sp.GetRequiredService<ISdk>();
+        var cts = new CancellationTokenSource();
 
         IDevice? lastDevice = null;
         huddlySdk.DeviceConnected += async (o, e) =>
@@ -38,7 +39,7 @@ internal class Program
             lastDevice = e.Device;
 
             var crewDevice = (IMultiCameraDevice)e.Device;
-            var connectedCamerasResult = await crewDevice.GetConnectedCameras();
+            var connectedCamerasResult = await crewDevice.GetConnectedCameras(cts.Token);
             if (!connectedCamerasResult.IsSuccess)
             {
                 Console.WriteLine(
@@ -64,8 +65,6 @@ internal class Program
                 lastDevice = null;
             }
         };
-
-        var cts = new CancellationTokenSource();
 
         Console.WriteLine("\n\nPress Control+C to quit the sample.\n\n");
         Console.CancelKeyPress += (sender, eventArgs) =>

--- a/Crew/Program.cs
+++ b/Crew/Program.cs
@@ -8,9 +8,8 @@ namespace Crew;
 
 internal class Program
 {
-    static void Main(string[] _)
+    static async Task Main(string[] _)
     {
-        var cts = new CancellationTokenSource();
         var services = new ServiceCollection();
         services.AddLogging(configure => configure.AddConsole().SetMinimumLevel(LogLevel.Debug));
 
@@ -53,7 +52,8 @@ internal class Program
             foreach (CameraStatus cameraStatus in crewCameraStatuses)
             {
                 Console.WriteLine(
-                    $"\tSerial: {cameraStatus.Serial}, Type: {cameraStatus.Type}, Availability: {cameraStatus.Availability}"
+                    $"\tSerial: {cameraStatus.Serial}, Type: {cameraStatus.Type}, "
+                        + $"Availability: {cameraStatus.Availability}"
                 );
             }
         };
@@ -66,7 +66,16 @@ internal class Program
             }
         };
 
-        huddlySdk.StartMonitoring();
-        Console.ReadKey();
+        var cts = new CancellationTokenSource();
+
+        Console.WriteLine("\n\nPress Control+C to quit the sample.\n\n");
+        Console.CancelKeyPress += (sender, eventArgs) =>
+        {
+            Console.WriteLine("Cancellation requested; will exit.");
+            eventArgs.Cancel = true;
+            cts.Cancel();
+        };
+
+        await huddlySdk.StartMonitoring(ct: cts.Token);
     }
 }

--- a/Crew/Program.cs
+++ b/Crew/Program.cs
@@ -1,6 +1,5 @@
 ﻿using Huddly.Device.Model;
 using Huddly.Sdk;
-using Huddly.Sdk.Models;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -49,7 +48,7 @@ internal class Program
             }
             var crewCameraStatuses = connectedCamerasResult.Value;
             Console.WriteLine($"Crew system with the following cameras connected:");
-            foreach (CameraStatus cameraStatus in crewCameraStatuses)
+            foreach (var cameraStatus in crewCameraStatuses)
             {
                 Console.WriteLine(
                     $"\tSerial: {cameraStatus.Serial}, Type: {cameraStatus.Type}, "

--- a/Detections/Detections.csproj
+++ b/Detections/Detections.csproj
@@ -5,6 +5,8 @@
 		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
+		<EnableNETAnalyzers>true</EnableNETAnalyzers>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Detections/Detections.csproj
+++ b/Detections/Detections.csproj
@@ -1,17 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Huddly.Sdk" Version="2.22.4" />
-    <PackageReference Include="Huddly.Sdk.Extensions" Version="2.22.4" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.1" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Huddly.Sdk" Version="2.22.4" />
+		<PackageReference Include="Huddly.Sdk.Extensions" Version="2.22.4" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.1" />
+	</ItemGroup>
 
 </Project>

--- a/Detections/Program.cs
+++ b/Detections/Program.cs
@@ -50,7 +50,6 @@ internal class Program
         };
         var sdkTask = huddlySdk.StartMonitoring(ct: cts.Token);
         await sdkTask;
-        huddlySdk.Dispose();
     }
 
     private static async void HandleDeviceConnected(

--- a/Detections/Program.cs
+++ b/Detections/Program.cs
@@ -42,7 +42,7 @@ internal class Program
             // First cancel all running detectors
             detectorCts.Cancel();
             // Wait for the running detectors to be stopped and disposed properly
-            await signal.WaitAsync();
+            await signal.WaitAsync(cts.Token);
             // Only after the detectors have been disposed do we cancel/dispose the sdk.
             cts.Cancel();
         };
@@ -59,7 +59,7 @@ internal class Program
         var device = eventArgs.Device;
         Console.WriteLine($"Device {device} connected");
 
-        await signal.WaitAsync();
+        await signal.WaitAsync(ct);
         await ConsumeDetections(device, ct);
         // Release the signal to indicate that the detector has been disposed gracefully.
         signal.Release();

--- a/Detections/Program.cs
+++ b/Detections/Program.cs
@@ -48,7 +48,7 @@ internal class Program
             // Only after the detectors have been disposed do we cancel/dispose the sdk.
             cts.Cancel();
         };
-        Task sdkTask = huddlySdk.StartMonitoring(ct: cts.Token);
+        var sdkTask = huddlySdk.StartMonitoring(ct: cts.Token);
         await sdkTask;
         huddlySdk.Dispose();
     }
@@ -60,7 +60,7 @@ internal class Program
         SemaphoreSlim signal
     )
     {
-        IDevice device = eventArgs.Device;
+        var device = eventArgs.Device;
         Console.WriteLine($"Device {device} connected");
 
         await signal.WaitAsync();
@@ -71,17 +71,17 @@ internal class Program
 
     private static async Task ConsumeDetections(IDevice device, CancellationToken ct)
     {
-        DetectorOptions detectorOptions = DetectorOptions.DefaultFor(device.Model);
+        var detectorOptions = DetectorOptions.DefaultFor(device.Model);
         detectorOptions.Mode = DetectorMode.AlwaysOn;
 
-        Result<IDetector> detectorResult = await device.GetDetector(detectorOptions, ct);
+        var detectorResult = await device.GetDetector(detectorOptions, ct);
         if (!detectorResult.IsSuccess)
         {
             Console.WriteLine($"Could not create detector: {detectorResult.Message}");
             return;
         }
 
-        IDetector detector = detectorResult.Value;
+        var detector = detectorResult.Value;
         try
         {
             // This loop will continue indefinitely until either:

--- a/Detections/Program.cs
+++ b/Detections/Program.cs
@@ -13,13 +13,11 @@ internal class Program
         var services = new ServiceCollection();
         services.AddLogging(configure => configure.AddConsole().SetMinimumLevel(LogLevel.Debug));
 
-        services.AddHuddlySdk(
-            configure =>
-            {
-                configure.UseUsbDeviceMonitor();
-                configure.UseIpDeviceMonitor();
-            }
-        );
+        services.AddHuddlySdk(configure =>
+        {
+            configure.UseUsbDeviceMonitor();
+            configure.UseIpDeviceMonitor();
+        });
 
         var sp = services.BuildServiceProvider();
 
@@ -91,7 +89,9 @@ internal class Program
             {
                 int personBoxCount = detections.Count(detection => detection.Label == "person");
                 int headBoxCount = detections.Count(detection => detection.Label == "head");
-                Console.WriteLine($"Received detections with {personBoxCount} person boxes and {headBoxCount} head boxes");
+                Console.WriteLine(
+                    $"Received detections with {personBoxCount} person boxes and {headBoxCount} head boxes"
+                );
             }
         }
         catch (Exception e)

--- a/Detections/Program.cs
+++ b/Detections/Program.cs
@@ -86,8 +86,8 @@ internal class Program
             // Note that the IAsyncEnumerable returned by GetDetections does not throw in either of these cases.
             await foreach (Huddly.Sdk.Models.Detections detections in detector.GetDetections(ct))
             {
-                int personBoxCount = detections.Count(detection => detection.Label == "person");
-                int headBoxCount = detections.Count(detection => detection.Label == "head");
+                var personBoxCount = detections.Count(detection => detection.Label == "person");
+                var headBoxCount = detections.Count(detection => detection.Label == "head");
                 Console.WriteLine(
                     $"Received detections with {personBoxCount} person boxes and {headBoxCount} head boxes"
                 );

--- a/Detections/Program.cs
+++ b/Detections/Program.cs
@@ -23,9 +23,9 @@ internal class Program
 
         // Should always be disposed after use
         using var huddlySdk = sp.GetRequiredService<ISdk>();
-
         var cts = new CancellationTokenSource();
-        // Create a separate cts specifically for cancelling detectors.
+
+        // Create a separate cts specifically to cancel detectors.
         var detectorCts = CancellationTokenSource.CreateLinkedTokenSource(cts.Token);
         // For signalling when detectors have been disposed properly
         var signal = new SemaphoreSlim(1, 1);
@@ -33,7 +33,7 @@ internal class Program
         huddlySdk.DeviceConnected += (sender, eventArgs) =>
             HandleDeviceConnected(sender, eventArgs, detectorCts.Token, signal);
 
-        Console.WriteLine("Press Control+C to quit the sample.");
+        Console.WriteLine("\n\nPress Control+C to quit the sample.\n\n");
         Console.CancelKeyPress += async (sender, eventArgs) =>
         {
             Console.WriteLine("Cancellation requested; will exit.");
@@ -46,8 +46,7 @@ internal class Program
             // Only after the detectors have been disposed do we cancel/dispose the sdk.
             cts.Cancel();
         };
-        var sdkTask = huddlySdk.StartMonitoring(ct: cts.Token);
-        await sdkTask;
+        await huddlySdk.StartMonitoring(ct: cts.Token);
     }
 
     private static async void HandleDeviceConnected(
@@ -99,7 +98,7 @@ internal class Program
             Console.WriteLine($"Detector threw exception: {e.Message}");
         }
         // Always dispose the detector properly after use.
-        // This should be completed before disposing/cancelling the ISdk from which the detector has been derived.
+        // This should be completed before disposing/canceling the ISdk from which the detector has been derived.
         await detector.DisposeAsync();
     }
 }

--- a/DeviceLogs/DeviceLogs.csproj
+++ b/DeviceLogs/DeviceLogs.csproj
@@ -5,6 +5,8 @@
 		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
+		<EnableNETAnalyzers>true</EnableNETAnalyzers>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/DeviceLogs/DeviceLogs.csproj
+++ b/DeviceLogs/DeviceLogs.csproj
@@ -1,17 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Huddly.Sdk" Version="2.22.4" />
-    <PackageReference Include="Huddly.Sdk.Extensions" Version="2.22.4" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.1" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Huddly.Sdk" Version="2.22.4" />
+		<PackageReference Include="Huddly.Sdk.Extensions" Version="2.22.4" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.1" />
+	</ItemGroup>
 
 </Project>

--- a/DeviceLogs/Program.cs
+++ b/DeviceLogs/Program.cs
@@ -1,5 +1,4 @@
-﻿using Huddly.Sdk.Models;
-using Huddly.Sdk;
+﻿using Huddly.Sdk;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -45,9 +44,9 @@ internal class Program
     static async Task RetrieveDeviceLogs(IDevice device, CancellationToken ct)
     {
         // Device logs can be written to any stream. Here we use the console output.
-        Stream outputStream = Console.OpenStandardOutput();
+        var outputStream = Console.OpenStandardOutput();
         Console.WriteLine($"---------- BEGIN DEVICE LOG FOR {device.Id} ---------- ");
-        Result getLogResult = await device.GetLog(outputStream, ct);
+        var getLogResult = await device.GetLog(outputStream, ct);
         Console.WriteLine($"---------- END DEVICE LOG FOR {device.Id} ---------- ");
 
         if (getLogResult.IsSuccess)

--- a/DeviceLogs/Program.cs
+++ b/DeviceLogs/Program.cs
@@ -11,13 +11,11 @@ internal class Program
         var services = new ServiceCollection();
         services.AddLogging(configure => configure.AddConsole().SetMinimumLevel(LogLevel.Debug));
 
-        services.AddHuddlySdk(
-            configure =>
-            {
-                configure.UseUsbDeviceMonitor();
-                configure.UseIpDeviceMonitor();
-            }
-        );
+        services.AddHuddlySdk(configure =>
+        {
+            configure.UseUsbDeviceMonitor();
+            configure.UseIpDeviceMonitor();
+        });
 
         var sp = services.BuildServiceProvider();
 

--- a/DeviceLogs/Program.cs
+++ b/DeviceLogs/Program.cs
@@ -21,7 +21,6 @@ internal class Program
 
         // Should always be disposed after use
         using var huddlySdk = sp.GetRequiredService<ISdk>();
-
         var cts = new CancellationTokenSource();
 
         huddlySdk.DeviceConnected += async (sender, eventArgs) =>
@@ -33,8 +32,15 @@ internal class Program
         huddlySdk.DeviceDisconnected += (sender, eventArgs) =>
             Console.WriteLine($"{eventArgs.Device.Id} disconnected");
 
-        var sdkStartTask = huddlySdk.StartMonitoring(ct: cts.Token);
-        await sdkStartTask;
+        Console.WriteLine("\n\nPress Control+C to quit the sample.\n\n");
+        Console.CancelKeyPress += (sender, eventArgs) =>
+        {
+            Console.WriteLine("Cancellation requested; will exit.");
+            eventArgs.Cancel = true;
+            cts.Cancel();
+        };
+
+        await huddlySdk.StartMonitoring(ct: cts.Token);
     }
 
     static async Task RetrieveDeviceLogs(IDevice device, CancellationToken ct)

--- a/DeviceLogs/Program.cs
+++ b/DeviceLogs/Program.cs
@@ -37,8 +37,6 @@ internal class Program
 
         var sdkStartTask = huddlySdk.StartMonitoring(ct: cts.Token);
         await sdkStartTask;
-
-        huddlySdk.Dispose();
     }
 
     static async Task RetrieveDeviceLogs(IDevice device, CancellationToken ct)

--- a/FramingModes/FramingModes.csproj
+++ b/FramingModes/FramingModes.csproj
@@ -5,6 +5,8 @@
 		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
+		<EnableNETAnalyzers>true</EnableNETAnalyzers>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/FramingModes/Program.cs
+++ b/FramingModes/Program.cs
@@ -13,13 +13,11 @@ internal class Program
         var services = new ServiceCollection();
         services.AddLogging(configure => configure.AddConsole().SetMinimumLevel(LogLevel.Debug));
 
-        services.AddHuddlySdk(
-            configure =>
-            {
-                configure.UseUsbDeviceMonitor();
-                configure.UseIpDeviceMonitor();
-            }
-        );
+        services.AddHuddlySdk(configure =>
+        {
+            configure.UseUsbDeviceMonitor();
+            configure.UseIpDeviceMonitor();
+        });
 
         var sp = services.BuildServiceProvider();
 
@@ -39,7 +37,10 @@ internal class Program
             var supportedFeatures = await lastDevice.GetSupportedFeatures();
 
             Console.WriteLine($"Supported framing modes:");
-            foreach (FramingMode supportedFraming in supportedFeatures.Value?.Framing ?? Enumerable.Empty<FramingMode>())
+            foreach (
+                FramingMode supportedFraming in supportedFeatures.Value?.Framing
+                    ?? Enumerable.Empty<FramingMode>()
+            )
             {
                 Console.WriteLine($"==== {supportedFraming}");
             }

--- a/FramingModes/Program.cs
+++ b/FramingModes/Program.cs
@@ -7,9 +7,8 @@ namespace FramingModes;
 
 internal class Program
 {
-    static void Main(string[] _)
+    static async Task Main(string[] _)
     {
-        var cts = new CancellationTokenSource();
         var services = new ServiceCollection();
         services.AddLogging(configure => configure.AddConsole().SetMinimumLevel(LogLevel.Debug));
 
@@ -58,16 +57,23 @@ internal class Program
             {
                 Console.WriteLine("Succesfully changed framing mode!");
             }
-
-            Console.WriteLine("Press any key to quit...");
         };
         huddlySdk.DeviceDisconnected += (o, e) =>
         {
             Console.WriteLine($"Device {e.Device.Id} disconnected");
             lastDevice = null;
         };
-        var sdkStartTask = huddlySdk.StartMonitoring();
 
-        Console.ReadKey();
+        var cts = new CancellationTokenSource();
+
+        Console.WriteLine("\n\nPress Control+C to quit the sample.\n\n");
+        Console.CancelKeyPress += (sender, eventArgs) =>
+        {
+            Console.WriteLine("Cancellation requested; will exit.");
+            eventArgs.Cancel = true;
+            cts.Cancel();
+        };
+
+        await huddlySdk.StartMonitoring(ct: cts.Token);
     }
 }

--- a/FramingModes/Program.cs
+++ b/FramingModes/Program.cs
@@ -22,6 +22,7 @@ internal class Program
 
         // Should always be disposed after use
         using var huddlySdk = sp.GetRequiredService<ISdk>();
+        var cts = new CancellationTokenSource();
 
         IDevice? lastDevice = null;
         huddlySdk.DeviceConnected += async (o, e) =>
@@ -29,11 +30,11 @@ internal class Program
             lastDevice = e.Device;
 
             // Get framing mode
-            var getFramingResult = await lastDevice.GetFramingMode();
+            var getFramingResult = await lastDevice.GetFramingMode(cts.Token);
             FramingMode? framing = getFramingResult.IsSuccess ? getFramingResult.Value : null;
             Console.WriteLine($"Current framing value: {getFramingResult.Value}");
 
-            var supportedFeatures = await lastDevice.GetSupportedFeatures();
+            var supportedFeatures = await lastDevice.GetSupportedFeatures(cts.Token);
 
             Console.WriteLine($"Supported framing modes:");
             foreach (
@@ -45,14 +46,14 @@ internal class Program
             }
 
             Console.WriteLine($"Changing framing mode to: {FramingMode.Manual}");
-            var setFramingResult = await lastDevice.SetFramingMode(FramingMode.Manual);
+            var setFramingResult = await lastDevice.SetFramingMode(FramingMode.Manual, cts.Token);
             if (setFramingResult.IsSuccess)
             {
                 Console.WriteLine("Succesfully changed framing mode!");
             }
 
             Console.WriteLine($"Changing framing mode to: {FramingMode.GeniusFraming}");
-            setFramingResult = await lastDevice.SetFramingMode(FramingMode.GeniusFraming);
+            setFramingResult = await lastDevice.SetFramingMode(FramingMode.GeniusFraming, cts.Token);
             if (setFramingResult.IsSuccess)
             {
                 Console.WriteLine("Succesfully changed framing mode!");
@@ -63,8 +64,6 @@ internal class Program
             Console.WriteLine($"Device {e.Device.Id} disconnected");
             lastDevice = null;
         };
-
-        var cts = new CancellationTokenSource();
 
         Console.WriteLine("\n\nPress Control+C to quit the sample.\n\n");
         Console.CancelKeyPress += (sender, eventArgs) =>

--- a/FramingModes/Program.cs
+++ b/FramingModes/Program.cs
@@ -37,7 +37,7 @@ internal class Program
 
             Console.WriteLine($"Supported framing modes:");
             foreach (
-                FramingMode supportedFraming in supportedFeatures.Value?.Framing
+                var supportedFraming in supportedFeatures.Value?.Framing
                     ?? Enumerable.Empty<FramingMode>()
             )
             {

--- a/FramingModes/Program.cs
+++ b/FramingModes/Program.cs
@@ -49,14 +49,14 @@ internal class Program
             var setFramingResult = await lastDevice.SetFramingMode(FramingMode.Manual, cts.Token);
             if (setFramingResult.IsSuccess)
             {
-                Console.WriteLine("Succesfully changed framing mode!");
+                Console.WriteLine("Successfully changed framing mode!");
             }
 
             Console.WriteLine($"Changing framing mode to: {FramingMode.GeniusFraming}");
             setFramingResult = await lastDevice.SetFramingMode(FramingMode.GeniusFraming, cts.Token);
             if (setFramingResult.IsSuccess)
             {
-                Console.WriteLine("Succesfully changed framing mode!");
+                Console.WriteLine("Successfully changed framing mode!");
             }
         };
         huddlySdk.DeviceDisconnected += (o, e) =>

--- a/FramingModes/Program.cs
+++ b/FramingModes/Program.cs
@@ -3,7 +3,7 @@ using Huddly.Sdk.Models;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
-namespace CameraInfo;
+namespace FramingModes;
 
 internal class Program
 {

--- a/Upgrade/Program.cs
+++ b/Upgrade/Program.cs
@@ -54,6 +54,5 @@ internal class Program
         };
         var sdkTask = huddlySdk.StartMonitoring(ct: cts.Token);
         await sdkTask;
-        huddlySdk.Dispose();
     }
 }

--- a/Upgrade/Program.cs
+++ b/Upgrade/Program.cs
@@ -52,7 +52,7 @@ internal class Program
             eventArgs.Cancel = true;
             cts.Cancel();
         };
-        Task sdkTask = huddlySdk.StartMonitoring(ct: cts.Token);
+        var sdkTask = huddlySdk.StartMonitoring(ct: cts.Token);
         await sdkTask;
         huddlySdk.Dispose();
     }

--- a/Upgrade/Program.cs
+++ b/Upgrade/Program.cs
@@ -23,7 +23,7 @@ internal class Program
         using var huddlySdk = sp.GetRequiredService<ISdk>();
         var cts = new CancellationTokenSource();
 
-        int numDevicesConnected = 0;
+        var numDevicesConnected = 0;
         huddlySdk.DeviceConnected += async (sender, eventArgs) =>
         {
             if (numDevicesConnected++ > 0)

--- a/Upgrade/Program.cs
+++ b/Upgrade/Program.cs
@@ -21,7 +21,6 @@ internal class Program
 
         // Should always be disposed after use
         using var huddlySdk = sp.GetRequiredService<ISdk>();
-
         var cts = new CancellationTokenSource();
 
         int numDevicesConnected = 0;
@@ -42,7 +41,8 @@ internal class Program
         };
 
         Console.WriteLine(
-            "Press Control+C to quit the sample. Note: Cancelling an ongoing upgrade is not recommended."
+            "\n\nPress Control+C to quit the sample. "
+                + "Note: Canceling an ongoing upgrade is not recommended.\n\n"
         );
         Console.CancelKeyPress += (sender, eventArgs) =>
         {
@@ -50,7 +50,7 @@ internal class Program
             eventArgs.Cancel = true;
             cts.Cancel();
         };
-        var sdkTask = huddlySdk.StartMonitoring(ct: cts.Token);
-        await sdkTask;
+
+        await huddlySdk.StartMonitoring(ct: cts.Token);
     }
 }

--- a/Upgrade/Program.cs
+++ b/Upgrade/Program.cs
@@ -11,13 +11,11 @@ internal class Program
         var services = new ServiceCollection();
         services.AddLogging(configure => configure.AddConsole().SetMinimumLevel(LogLevel.Debug));
 
-        services.AddHuddlySdk(
-            configure =>
-            {
-                configure.UseUsbDeviceMonitor();
-                configure.UseIpDeviceMonitor();
-            }
-        );
+        services.AddHuddlySdk(configure =>
+        {
+            configure.UseUsbDeviceMonitor();
+            configure.UseIpDeviceMonitor();
+        });
 
         var sp = services.BuildServiceProvider();
 

--- a/Upgrade/Upgrade.csproj
+++ b/Upgrade/Upgrade.csproj
@@ -5,6 +5,8 @@
 		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
+		<EnableNETAnalyzers>true</EnableNETAnalyzers>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Upgrade/Upgrade.csproj
+++ b/Upgrade/Upgrade.csproj
@@ -1,17 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Huddly.Sdk" Version="2.22.4" />
-    <PackageReference Include="Huddly.Sdk.Extensions" Version="2.22.4" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.1" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Huddly.Sdk" Version="2.22.4" />
+		<PackageReference Include="Huddly.Sdk.Extensions" Version="2.22.4" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.1" />
+	</ItemGroup>
 
 </Project>

--- a/Upgrade/UpgradeRunner.cs
+++ b/Upgrade/UpgradeRunner.cs
@@ -43,7 +43,7 @@ public class UpgradeRunner
         if (deviceFirmwareVersion >= remoteFirmwareInfo.FirmwareVersion)
         {
             Console.WriteLine(
-                "Latest firmware release is not greater than the current device firmware. Exiting"
+                "Latest firmware release is not greater than the current device firmware."
             );
             return;
         }

--- a/Upgrade/UpgradeRunner.cs
+++ b/Upgrade/UpgradeRunner.cs
@@ -18,11 +18,15 @@ public class UpgradeRunner
         if (!remoteFirmwareInfoResult.IsSuccess)
         {
             string errorMessage = remoteFirmwareInfoResult.Message;
-            Console.WriteLine($"Failed retrieving latest firmware version: {errorMessage}. Aborting.");
+            Console.WriteLine(
+                $"Failed retrieving latest firmware version: {errorMessage}. Aborting."
+            );
             return;
         }
         var remoteFirmwareInfo = remoteFirmwareInfoResult.Value;
-        Console.WriteLine($"Latest available firmware release is version {remoteFirmwareInfo.FirmwareVersion}");
+        Console.WriteLine(
+            $"Latest available firmware release is version {remoteFirmwareInfo.FirmwareVersion}"
+        );
 
         // Check if the latest firmware is greater than the current device version
         // This step is optional: Upgrades can be performed to any version.
@@ -38,11 +42,15 @@ public class UpgradeRunner
         var deviceFirmwareVersion = deviceFirmwareVersionResult.Value;
         if (deviceFirmwareVersion >= remoteFirmwareInfo.FirmwareVersion)
         {
-            Console.WriteLine("Latest firmware release is not greater than the current device firmware. Exiting");
+            Console.WriteLine(
+                "Latest firmware release is not greater than the current device firmware. Exiting"
+            );
             return;
         }
-        Console.WriteLine("Latest firmware release is greater than the current device firmware. Proceeding with upgrade.");
-        
+        Console.WriteLine(
+            "Latest firmware release is greater than the current device firmware. Proceeding with upgrade."
+        );
+
         var httpClient = new HttpClient();
         using HttpResponseMessage response = await httpClient.GetAsync(
             remoteFirmwareInfo.DownloadUrl,

--- a/Upgrade/UpgradeRunner.cs
+++ b/Upgrade/UpgradeRunner.cs
@@ -1,6 +1,5 @@
 ﻿using Huddly.Sdk;
 using Huddly.Sdk.Models;
-using Huddly.Sdk.Upgraders;
 
 namespace Upgrade;
 
@@ -12,7 +11,7 @@ public class UpgradeRunner
     )
     {
         // Get information on the latest available release for the device
-        Result<RemoteFirmwareInfo> remoteFirmwareInfoResult = await device.FirmwareChecker.GetLatestRemoteVersion(
+        var remoteFirmwareInfoResult = await device.FirmwareChecker.GetLatestRemoteVersion(
             FirmwareChannel.Stable,
             ct
         );
@@ -22,12 +21,12 @@ public class UpgradeRunner
             Console.WriteLine($"Failed retrieving latest firmware version: {errorMessage}. Aborting.");
             return;
         }
-        RemoteFirmwareInfo remoteFirmwareInfo = remoteFirmwareInfoResult.Value;
+        var remoteFirmwareInfo = remoteFirmwareInfoResult.Value;
         Console.WriteLine($"Latest available firmware release is version {remoteFirmwareInfo.FirmwareVersion}");
 
         // Check if the latest firmware is greater than the current device version
         // This step is optional: Upgrades can be performed to any version.
-        Result<FirmwareVersion> deviceFirmwareVersionResult = await device.GetFirmwareVersion(ct);
+        var deviceFirmwareVersionResult = await device.GetFirmwareVersion(ct);
         if (!deviceFirmwareVersionResult.IsSuccess)
         {
             string errorMessage = deviceFirmwareVersionResult.Message;
@@ -36,7 +35,7 @@ public class UpgradeRunner
             );
             return;
         }
-        FirmwareVersion deviceFirmwareVersion = deviceFirmwareVersionResult.Value;
+        var deviceFirmwareVersion = deviceFirmwareVersionResult.Value;
         if (deviceFirmwareVersion >= remoteFirmwareInfo.FirmwareVersion)
         {
             Console.WriteLine("Latest firmware release is not greater than the current device firmware. Exiting");
@@ -44,7 +43,7 @@ public class UpgradeRunner
         }
         Console.WriteLine("Latest firmware release is greater than the current device firmware. Proceeding with upgrade.");
         
-        HttpClient httpClient = new HttpClient();
+        var httpClient = new HttpClient();
         using HttpResponseMessage response = await httpClient.GetAsync(
             remoteFirmwareInfo.DownloadUrl,
             HttpCompletionOption.ResponseHeadersRead,
@@ -55,7 +54,7 @@ public class UpgradeRunner
             Console.WriteLine("Failed trying to download firmware. Aborting.");
         }
 
-        string firmwareFilePath = Path.GetTempFileName();
+        var firmwareFilePath = Path.GetTempFileName();
         using (
             var fileStream = new FileStream(
                 firmwareFilePath,
@@ -72,7 +71,7 @@ public class UpgradeRunner
 
         try
         {
-            IFirmwareUpgrader deviceUpgrader = await device.GetFirmwareUpgrader(firmwareFilePath, ct);
+            var deviceUpgrader = await device.GetFirmwareUpgrader(firmwareFilePath, ct);
             // Subscribe to this event before Executing the upgrade to see upgrade progress.
             deviceUpgrader.ProgressUpdated += (sender, e) =>
                 Console.WriteLine(
@@ -87,7 +86,7 @@ public class UpgradeRunner
             // such, the original Huddly.Sdk.IDevice instance that was used to create the Huddly.Sdk.Upgraders.IFirmwareUpgrader
             // will disconnect. To continue communicating with the device when it has reconnected,
             // consumers should use the new Huddly.Sdk.IDevice instance emitted in the Huddly.Sdk.ISdk.DeviceConnected event
-            Result upgradeResult = await deviceUpgrader.Execute(ct);
+            var upgradeResult = await deviceUpgrader.Execute(ct);
             if (!upgradeResult.IsSuccess)
             {
                 Console.WriteLine($"Upgrade failed: {upgradeResult.Message}");


### PR DESCRIPTION
- Use var instead of explicit type declaration
- Use correct namespace for FramingModes sample project
- Don't explicitly dispose IDisposable huddlySdk when declared with "using" statement
- Fix formatting
- Enable basic code analysis
- Handle cancellation consistently across samples