### PR TITLE
SDK-880/Update .NET version to 10.0 and Huddly SDK to version 2.35.1

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
 
       - name: Build solution
         shell: bash

--- a/CameraInfo/CameraInfo.csproj
+++ b/CameraInfo/CameraInfo.csproj
@@ -12,7 +12,6 @@
 	<ItemGroup>
 		<PackageReference Include="Huddly.Sdk" Version="2.35.1" />
 		<PackageReference Include="Huddly.Sdk.Extensions" Version="2.35.1" />
-		<PackageReference Include="MessagePack" Version="3.1.7" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
 	</ItemGroup>

--- a/CameraInfo/CameraInfo.csproj
+++ b/CameraInfo/CameraInfo.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<EnableNETAnalyzers>true</EnableNETAnalyzers>
@@ -10,10 +10,11 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Huddly.Sdk" Version="2.22.4" />
-		<PackageReference Include="Huddly.Sdk.Extensions" Version="2.22.4" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.1" />
+		<PackageReference Include="Huddly.Sdk" Version="2.35.1" />
+		<PackageReference Include="Huddly.Sdk.Extensions" Version="2.35.1" />
+		<PackageReference Include="MessagePack" Version="3.1.7" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
 	</ItemGroup>
 
 </Project>

--- a/Crew/Crew.csproj
+++ b/Crew/Crew.csproj
@@ -12,7 +12,6 @@
 	<ItemGroup>
 		<PackageReference Include="Huddly.Sdk" Version="2.35.1" />
 		<PackageReference Include="Huddly.Sdk.Extensions" Version="2.35.1" />
-		<PackageReference Include="MessagePack" Version="3.1.7" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
 	</ItemGroup>

--- a/Crew/Crew.csproj
+++ b/Crew/Crew.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<EnableNETAnalyzers>true</EnableNETAnalyzers>
@@ -10,10 +10,11 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Huddly.Sdk" Version="2.22.4" />
-		<PackageReference Include="Huddly.Sdk.Extensions" Version="2.22.4" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.1" />
+		<PackageReference Include="Huddly.Sdk" Version="2.35.1" />
+		<PackageReference Include="Huddly.Sdk.Extensions" Version="2.35.1" />
+		<PackageReference Include="MessagePack" Version="3.1.7" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
 	</ItemGroup>
 
 </Project>

--- a/Detections/Detections.csproj
+++ b/Detections/Detections.csproj
@@ -12,7 +12,6 @@
 	<ItemGroup>
 		<PackageReference Include="Huddly.Sdk" Version="2.35.1" />
 		<PackageReference Include="Huddly.Sdk.Extensions" Version="2.35.1" />
-		<PackageReference Include="MessagePack" Version="3.1.7" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
 	</ItemGroup>

--- a/Detections/Detections.csproj
+++ b/Detections/Detections.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<EnableNETAnalyzers>true</EnableNETAnalyzers>
@@ -10,10 +10,11 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Huddly.Sdk" Version="2.22.4" />
-		<PackageReference Include="Huddly.Sdk.Extensions" Version="2.22.4" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.1" />
+		<PackageReference Include="Huddly.Sdk" Version="2.35.1" />
+		<PackageReference Include="Huddly.Sdk.Extensions" Version="2.35.1" />
+		<PackageReference Include="MessagePack" Version="3.1.7" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
 	</ItemGroup>
 
 </Project>

--- a/DeviceLogs/DeviceLogs.csproj
+++ b/DeviceLogs/DeviceLogs.csproj
@@ -12,7 +12,6 @@
 	<ItemGroup>
 		<PackageReference Include="Huddly.Sdk" Version="2.35.1" />
 		<PackageReference Include="Huddly.Sdk.Extensions" Version="2.35.1" />
-		<PackageReference Include="MessagePack" Version="3.1.7" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
 	</ItemGroup>

--- a/DeviceLogs/DeviceLogs.csproj
+++ b/DeviceLogs/DeviceLogs.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<EnableNETAnalyzers>true</EnableNETAnalyzers>
@@ -10,10 +10,11 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Huddly.Sdk" Version="2.22.4" />
-		<PackageReference Include="Huddly.Sdk.Extensions" Version="2.22.4" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.1" />
+		<PackageReference Include="Huddly.Sdk" Version="2.35.1" />
+		<PackageReference Include="Huddly.Sdk.Extensions" Version="2.35.1" />
+		<PackageReference Include="MessagePack" Version="3.1.7" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
 	</ItemGroup>
 
 </Project>

--- a/FramingModes/FramingModes.csproj
+++ b/FramingModes/FramingModes.csproj
@@ -12,7 +12,6 @@
 	<ItemGroup>
 		<PackageReference Include="Huddly.Sdk" Version="2.35.1" />
 		<PackageReference Include="Huddly.Sdk.Extensions" Version="2.35.1" />
-		<PackageReference Include="MessagePack" Version="3.1.7" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
 	</ItemGroup>

--- a/FramingModes/FramingModes.csproj
+++ b/FramingModes/FramingModes.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<EnableNETAnalyzers>true</EnableNETAnalyzers>
@@ -10,10 +10,11 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Huddly.Sdk" Version="2.22.4" />
-		<PackageReference Include="Huddly.Sdk.Extensions" Version="2.22.4" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.1" />
+		<PackageReference Include="Huddly.Sdk" Version="2.35.1" />
+		<PackageReference Include="Huddly.Sdk.Extensions" Version="2.35.1" />
+		<PackageReference Include="MessagePack" Version="3.1.7" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
 	</ItemGroup>
 
 </Project>

--- a/Upgrade/Upgrade.csproj
+++ b/Upgrade/Upgrade.csproj
@@ -12,7 +12,6 @@
 	<ItemGroup>
 		<PackageReference Include="Huddly.Sdk" Version="2.35.1" />
 		<PackageReference Include="Huddly.Sdk.Extensions" Version="2.35.1" />
-		<PackageReference Include="MessagePack" Version="3.1.7" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
 	</ItemGroup>

--- a/Upgrade/Upgrade.csproj
+++ b/Upgrade/Upgrade.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<EnableNETAnalyzers>true</EnableNETAnalyzers>
@@ -10,10 +10,11 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Huddly.Sdk" Version="2.22.4" />
-		<PackageReference Include="Huddly.Sdk.Extensions" Version="2.22.4" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.1" />
+		<PackageReference Include="Huddly.Sdk" Version="2.35.1" />
+		<PackageReference Include="Huddly.Sdk.Extensions" Version="2.35.1" />
+		<PackageReference Include="MessagePack" Version="3.1.7" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
**What:**
Update .NET version to 10.0 and Huddly SDK to version 2.35.1
Removed explicit MessagePack reference from sample projects

**Why:**
Huddly.Sdk 2.35.1 already resolves a patched MessagePack version
transitively, making the direct override unnecessary.
